### PR TITLE
Update and improve public_log_parser

### DIFF
--- a/public_log_parser.php
+++ b/public_log_parser.php
@@ -1,8 +1,12 @@
 <?php
-//This has very little documentation, edit the server array around line 175 to your server(s) 
+//This has very little documentation, and is a hobbled togeather mess where speed to code and preformance of the code were placed before code readability or maintainability. Only works on linux. Requires gzip and gunzip shell commands as well as the php extentions.
+
+//	edit the server array below to your server(s) 
 //	symlink server-gamedata/servername to the static folder of tgs3 (gamedata folder for tgs2), and symlink parsed-logs to a folder accessable by the webserver
-//	you also need the runtime condenser in the folder rc, with the binary named rc.
-//	it creates .gz files, you can abuse http-gzip-static and a few rewrite rules in nginx to make nginx serve them up as gzip compressed text files.
+//	you also need the runtime condenser in the folder rc, with the binary named rc
+//	it creates .gz files, you can abuse http-gzip-static and a few rewrite rules in nginx to make nginx serve them up as http-gzip compressed text files.
+
+$servers = array('sybil', 'basil');
 
 if (php_sapi_name() != "cli")
 	exit;
@@ -77,7 +81,15 @@ function compressfile($file, $target = null) {
 		exec('gzip -f9 "'.$file.'"');
 	}
 }
-function parseruntime($runtime, $newpath) {
+
+function condense_runtimes($infile, $outfile) {
+	echo "Condensing runtime: $infile -> $outfile\n";
+	chdir('rc');
+	exec('gunzip -kc ../"'.$infile.'" | ./rc -s | gzip -c9 > ../"'.$outfile.'"');
+	chdir('..');
+}
+
+function parseruntime($runtime, $newpath, $monthruntimes, $dayruntimes) {
 	echo "parsing runtime: $runtime -> $newpath/runtime.log\n";
 	
 	$file = fopen($runtime, 'rb');
@@ -88,7 +100,6 @@ function parseruntime($runtime, $newpath) {
 		fclose($file);
 		return;
 	}
-	$condensefile = fopen('rc/Input.txt', 'wb');
 
 	//parse each line
 	while (($line = fgets($file)) !== false) {
@@ -97,19 +108,14 @@ function parseruntime($runtime, $newpath) {
 		//Remove byond printed strings
 		$line = preg_replace('/.*Cannot read \".*/', '-censored (string output)', $line);
 
-		//write it to the public location
+		//write it to the public locations
 		gzwrite($newfile, $line);
-		//write it to the runtime condenser
-		fwrite($condensefile, $line);
+		gzwrite($monthruntimes, $line);
+		gzwrite($dayruntimes, $line);
 	}
 	fclose($file);
 	gzclose($newfile);
-	fclose($condensefile);
-	echo "Condensing runtime: $runtime\n";
-	chdir('rc');
-	exec('./rc</dev/null');
-	chdir('..');
-	compressfile('rc/Output.txt', $newpath.'/runtime.condensed.txt');
+	condense_runtimes($newpath.'/runtime.txt.gz', $newpath.'/runtime.condensed.txt.gz');
 
 	//compressfile($newfilename.'-condensed.txt');
 	echo "Parse finished on runtime: $runtime\n";
@@ -117,8 +123,8 @@ function parseruntime($runtime, $newpath) {
 
 function updateconfig($server) {
 	$serverfiles = array('config/game_options.txt', 'config/maps.txt', 'config/unbuyableshuttles.txt', 'config/lavaruinblacklist.txt', 'config/spaceruinblacklist.txt', 'config/awaymissionconfig.txt');
-	$serverfolders = array('data/minimaps', 'data/npc_saves');
-	$filteredfiles = array('config/config.txt', 'config/comms.txt'); //todo, remove config.txt
+	$serverfolders = array('data/minimaps', 'data/npc_saves', 'data/Diagnostics/Resources');
+	$filteredfiles = array('config/config.txt');
 	$sharedfiles = array('admins.txt', 'admin_ranks.txt');
 	if (!file_exists('parsed-logs/'.$server))
 			mkdir('parsed-logs/'.$server, 0775, true);
@@ -176,6 +182,26 @@ function filterconfig($server, $configfile) {
 	}
 	echo "done filtering $configfile";
 }
+
+function fillzips($file, $basename, $monthzip, $dayzip, $roundzip, $day, $round) {
+	$handle = gzopen($file, 'r');
+	
+	$monthzip[$day.'/'.$round.'/'.$basename] = $handle;
+	$monthzip[$day.'/'.$round.'/'.$basename]->compress(Phar::BZ2);
+	
+	gzrewind($handle);
+	
+	$dayzip[$round.'/'.$basename] = $handle;
+	$dayzip[$round.'/'.$basename]->compress(Phar::BZ2);
+	
+	gzrewind($handle);
+	
+	$roundzip[$basename] = $handle;
+	$roundzip[$basename]->compress(Phar::BZ2);
+
+	gzclose($handle);
+}
+
 echo "Starting up\n";
 $servers = array('sybil', 'basil');
 foreach ($servers as $server) {
@@ -200,18 +226,21 @@ foreach ($servers as $server) {
 			$wrotemonth = false;
 			if (!is_numeric($basemonth))
 				continue;
-			if (!file_exists("$basenewpath/$baseyear"))
-				mkdir("$basenewpath/$baseyear",0775,true);
+			if (!file_exists("$basenewpath/$baseyear/$basemonth"))
+				mkdir("$basenewpath/$baseyear/$basemonth", 0775, true);
+			
 			$monthzip = new PharData("$basenewpath/$baseyear/month.$baseyear-$basemonth.zip", Phar::CURRENT_AS_FILEINFO | Phar::KEY_AS_FILENAME, null, Phar::ZIP);
 			$monthzip->startBuffering();
+			$monthruntimes = gzopen("$basenewpath/$baseyear/$basemonth/$baseyear-$basemonth.runtime.txt.gz", "ab9");
 			$days = array_reverse(getfoldersinfolder($month));
 			foreach ($days as $day) {
 				$baseday = basename($day);
 				$wroteday = false;
-				if (!file_exists("$basenewpath/$baseyear/$basemonth"))
-					mkdir("$basenewpath/$baseyear/$basemonth",0775,true);
+				if (!file_exists("$basenewpath/$baseyear/$basemonth/$baseday"))
+					mkdir("$basenewpath/$baseyear/$basemonth/$baseday", 0775, true);
 				$dayzip = new PharData("$basenewpath/$baseyear/$basemonth/day.$baseyear-$basemonth-$baseday.zip", Phar::CURRENT_AS_FILEINFO | Phar::KEY_AS_FILENAME, null, Phar::ZIP);
 				$dayzip->startBuffering();
+				$dayruntimes = gzopen("$basenewpath/$baseyear/$basemonth/$baseday/$baseyear-$basemonth-$baseday.runtime.txt.gz", "ab9");
 				$rounds = array_reverse(getfoldersinfolder($day));
 				foreach ($rounds as $round) {
 					$baseround = basename($round);
@@ -234,6 +263,11 @@ foreach ($servers as $server) {
 					} else {
 						$dayzip->stopBuffering();
 						$monthzip->stopBuffering();
+						gzclose($monthruntimes);
+						condense_runtimes("$basenewpath/$baseyear/$basemonth/$baseyear-$basemonth.runtime.txt.gz", "$basenewpath/$baseyear/$basemonth/$baseyear-$basemonth.runtime.condensed.txt.gz");
+						gzclose($dayruntimes);
+						condense_runtimes("$basenewpath/$baseyear/$basemonth/$baseday/$baseyear-$basemonth-$baseday.runtime.txt.gz", "$basenewpath/$baseyear/$basemonth/$baseday/$baseyear-$basemonth-$baseday.runtime.condensed.txt.gz");
+
 						break 4;
 					}
 					$roundzip = new PharData($newpath.'.zip', Phar::CURRENT_AS_FILEINFO | Phar::KEY_AS_FILENAME, null, Phar::ZIP);
@@ -242,70 +276,54 @@ foreach ($servers as $server) {
 					$logfiles = getfilesinfolder($round);
 					foreach ($logfiles as $logfile) {
 						$basename = basename($logfile);
-						switch ($basename) { //DON'T JUDGE ME OK.
+						switch ($basename) {
 							case 'game.log':
-								parsegamelog($logfile, $newpath, TRUE, TRUE);
-								$handle = gzopen($newpath.'/game.txt.gz', 'r');
-								$monthzip[$baseday.'/'.$baseround.'/game.txt'] = $handle;
-								$monthzip[$baseday.'/'.$baseround.'/game.txt']->compress(Phar::BZ2);
+								parselog($logfile, $newpath, TRUE, TRUE);
+								$basefilename = basename($basename, '.log');
+								$fullnewpath = $newpath.'/'.$basefilename.'.txt';
 								
-								$handle = gzopen($newpath.'/game.txt.gz', 'r'); //writing a handle consumes it, so we have to re-open this =\
-								$dayzip[$baseround.'/game.txt'] = $handle;
-								$dayzip[$baseround.'/game.txt']->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/game.txt.gz', 'r');
-								$roundzip['game.txt'] = $handle;
-								$roundzip['game.txt']->compress(Phar::BZ2);
+								fillzips($fullnewpath.'.gz', $basefilename.'.txt', $monthzip, $dayzip, $roundzip, $baseday, $baseround);
 								
-								gzclose($handle); //as far as I can tell its already closed at this point but this doesn't error out.
+								$fullnewpath = $newpath.'/'.$basefilename.'.html';
+								
+								fillzips($fullnewpath.'.gz', $basefilename.'.html', $monthzip, $dayzip, $roundzip, $baseday, $baseround);
 								break;
+							
 							case 'runtime.log':
-								parseruntime($logfile, $newpath);
-								$handle = gzopen($newpath.'/runtime.txt.gz', 'r');
-								$monthzip[$baseday.'/'.$baseround.'/runtime.txt'] = $handle;
-								$monthzip[$baseday.'/'.$baseround.'/runtime.txt']->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/runtime.txt.gz', 'r');
-								$dayzip[$baseround.'/runtime.txt'] = $handle;
-								$dayzip[$baseround.'/runtime.txt']->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/runtime.txt.gz', 'r');
-								$roundzip['runtime.txt'] = $handle;
-								$roundzip['runtime.txt']->compress(Phar::BZ2);
+								parseruntime($logfile, $newpath, $monthruntimes, $dayruntimes);
+								$basefilename = basename($basename, '.log');
+								$fullnewpath = $newpath.'/'.$basefilename.'.txt';
 								
-								gzclose($handle);
+								fillzips($fullnewpath.'.gz', $basefilename.'.txt', $monthzip, $dayzip, $roundzip, $baseday, $baseround);
+								
+								$fullnewpath = $newpath.'/'.$basefilename.'.condensed.txt';
+								
+								fillzips($fullnewpath.'.gz', $basefilename.'.condensed.txt', $monthzip, $dayzip, $roundzip, $baseday, $baseround);
+								
 								break;
-								
+							
 							case 'sql.log':
-								parsegamelog($logfile, $newpath, FALSE, FALSE);
-								$handle = gzopen($newpath.'/sql.txt.gz', 'r');
-								$monthzip[$baseday.'/'.$baseround.'/sql.txt'] = $handle;
-								$monthzip[$baseday.'/'.$baseround.'/sql.txt']->compress(Phar::BZ2);
+								parselog($logfile, $newpath, FALSE, FALSE);
+								$basefilename = basename($basename, '.log');
+								$fullnewpath = $newpath.'/'.$basefilename.'.txt';
 								
-								$handle = gzopen($newpath.'/sql.txt.gz', 'r'); //writing a handle consumes it, so we have to re-open this =\
-								$dayzip[$baseround.'/sql.txt'] = $handle;
-								$dayzip[$baseround.'/sql.txt']->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/sql.txt.gz', 'r');
-								$roundzip['sql.txt'] = $handle;
-								$roundzip['sql.txt']->compress(Phar::BZ2);
+								fillzips($fullnewpath.'.gz', $basefilename.'.txt', $monthzip, $dayzip, $roundzip, $baseday, $baseround);
+								
 								break;
-								
 							case 'attack.log':
 							case 'qdel.log':
 							case 'initialize.log':
 							case 'pda.log':
+							case 'overlay.log':
 							case 'manifest.log':
-								compressfile($logfile, $newpath.'/'.basename($basename, ".log").'.txt');
+								$basefilename = basename($basename, '.log');
+								$fullnewpath = $newpath.'/'.$basefilename.'.txt';
 								
-								$handle = gzopen($newpath.'/'.basename($basename, ".log").'.txt.gz', 'r');
-								$monthzip[$baseday.'/'.$baseround.'/'.basename($basename, ".log").'.txt'] = $handle;
-								$monthzip[$baseday.'/'.$baseround.'/'.basename($basename, ".log").'.txt']->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/'.basename($basename, ".log").'.txt.gz', 'r');
-								$dayzip[$baseround.'/'.basename($basename, ".log").'.txt'] = $handle;
-								$dayzip[$baseround.'/'.basename($basename, ".log").'.txt']->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/'.basename($basename, ".log").'.txt.gz', 'r');
-								$roundzip[basename($basename, ".log").'.txt'] = $handle;
-								$roundzip[basename($basename, ".log").'.txt']->compress(Phar::BZ2);
+								compressfile($logfile, $fullnewpath);
 								
-								gzclose($handle);
+								fillzips($fullnewpath.'.gz', $basefilename.'.txt', $monthzip, $dayzip, $roundzip, $baseday, $baseround);
 								break;
+							
 							case 'kudzu.html':
 							case 'wires.html':
 							case 'atmos.html':
@@ -317,19 +335,18 @@ foreach ($servers as $server) {
 							case 'supermatter.html':
 							case 'botany.html':
 							case 'telesci.html':
-								compressfile($logfile, $newpath.'/'.$basename);
-								$handle = gzopen($newpath.'/'.$basename.'.gz', 'r');
-								$monthzip[$baseday.'/'.$baseround.'/'.$basename] = $handle;
-								$monthzip[$baseday.'/'.$baseround.'/'.$basename]->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/'.$basename.'.gz', 'r');
-								$dayzip[$baseround.'/'.$basename] = $handle;
-								$dayzip[$baseround.'/'.$basename]->compress(Phar::BZ2);
-								$handle = gzopen($newpath.'/'.$basename.'.gz', 'r');
-								$roundzip[$basename] = $handle;
-								$roundzip[$basename]->compress(Phar::BZ2);
+							case 'research.html':
+							case 'radiation.html':
+							case 'portals.html':
+							case 'hallucinations.html':
+							case 'newscaster.json':
+								$fullnewpath = $newpath.'/'.$basename;
 								
-								gzclose($handle);
+								compressfile($logfile, $fullnewpath);
+								
+								fillzips($fullnewpath.'.gz', $basename, $monthzip, $dayzip, $roundzip, $baseday, $baseround);
 								break;
+							
 							case 'config_error.log':
 							case 'hrefs.html':
 								break;
@@ -338,11 +355,37 @@ foreach ($servers as $server) {
 								break;
 						}
 					}
+					$logfolders = getfoldersinfolder($round);
+					foreach ($logfolders as $logfolder) {
+						$basename = basename($logfolder);
+						switch ($basename) {
+							case 'photos':
+								if (!file_exists($newpath.'/photos'))
+										mkdir($newpath.'/photos',0775,true);
+								foreach (getfilesinfolder($logfolder) as $picturefile) {
+									$basename = basename($picturefile);
+									$fullnewpath = $newpath.'/photos/'.$basename;
+									
+									copy($picturefile, $fullnewpath);
+									
+									fillzips($fullnewpath, 'photos/'.$basename, $monthzip, $dayzip, $roundzip, $baseday, $baseround);
+								}
+							break;
+							default:
+								echo "(folder default) $logfile => $newpath/$basename\n";
+								break;
+						}
+						
+					}
 					$roundzip->stopBuffering();
 				}
 				$dayzip->stopBuffering();
+				gzclose($dayruntimes);
+				condense_runtimes("$basenewpath/$baseyear/$basemonth/$baseday/$baseyear-$basemonth-$baseday.runtime.txt.gz", "$basenewpath/$baseyear/$basemonth/$baseday/$baseyear-$basemonth-$baseday.runtime.condensed.txt.gz");
 			}
 			$monthzip->stopBuffering();
+			gzclose($monthruntimes);
+			condense_runtimes("$basenewpath/$baseyear/$basemonth/$baseyear-$basemonth.runtime.txt.gz", "$basenewpath/$baseyear/$basemonth/$baseyear-$basemonth.runtime.condensed.txt.gz");
 		}
 	}
 }
@@ -380,7 +423,9 @@ function parselog($logfile, $newpath, $lineparse, $htmlify) {
 	
 	while (($line = fgets($file)) !== false) {
 		$rawline = trim($line, "\n\r");
-		$parsedline = parseline($rawline, htmlspecialchars($line));
+		$parsedline = $rawline;
+		if ($lineparse)
+			$parsedline = parseline($rawline, htmlspecialchars($line));
 		$html = "";
 		if ($htmlify)
 			$html = preg_replace('/(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?|[0-9])/', '<span class="censored">-censored(ip)-</span>', $parsedline[1]);
@@ -476,14 +521,5 @@ function parseline ($line, $html) {
 function censor($reason) {
 	return array('-censored('.$reason.')-','<p class="censored">-censored('.$reason.')-</p>');
 }
-	
-	
-	
-	
-	
-	
-	
-	
-	
 
 ?>


### PR DESCRIPTION
adds support for day and month runtime commulations, adds photo support, adds whitelisting for a bunch of new files.

Porting notes: requires tgstation/tgstation#33702


Known issues: runtimes commulations have rounds in a reverse order to what would be expected. This isn't easily fixable. 