### PR TITLE
Adds shuttle.log parsing

### DIFF
--- a/public_log_parser.php
+++ b/public_log_parser.php
@@ -330,6 +330,7 @@ foreach ($servers as $server) {
 							case 'manifest.log':
 							case 'job_debug.log':
 							case 'virus.log':
+							case 'shuttle.log':
 								$basefilename = basename($basename, '.log');
 								$fullnewpath = $newpath.'/'.$basefilename.'.txt';
 								


### PR DESCRIPTION
This PR adds parsing for shuttle.log; the file was always intended to be available in parsed-logs