### PR TITLE
Add dynamic.json to parsed logs

### DIFF
--- a/public_log_parser.php
+++ b/public_log_parser.php
@@ -357,6 +357,7 @@ foreach ($servers as $server) {
 							case 'circuit.html':
 							case 'nanites.html':
 							case 'newscaster.json':
+							case 'dynamic.json':
 							case 'round_end_data.json':
 								$fullnewpath = $newpath.'/'.$basename;
 								


### PR DESCRIPTION
Not to be confused with the config file, this is a log file that will store what rulesets a dynamic round has, its threat, etc.

This isn't a log file that exists now, but will in the future, and so it would be nice to have this on the parser in preparation.

If you would rather this be delayed until the feature that is going to use this is test merged, let me know and I can make that happen.