### PR TITLE
Replaces singulo and supermatter with engine.html

### DIFF
--- a/public_log_parser.php
+++ b/public_log_parser.php
@@ -472,9 +472,8 @@ foreach ($servers as $server) {
 							case 'cargo.html':
 							case 'gravity.html':
 							case 'records.html':
-							case 'singulo.html':
 							case 'experimentor.html':
-							case 'supermatter.html':
+							case 'engine.html':
 							case 'botany.html':
 							case 'presents.html':
 							case 'telesci.html':

--- a/public_log_parser.php
+++ b/public_log_parser.php
@@ -472,7 +472,9 @@ foreach ($servers as $server) {
 							case 'cargo.html':
 							case 'gravity.html':
 							case 'records.html':
+							case 'singulo.html':
 							case 'experimentor.html':
+							case 'supermatter.html':
 							case 'engine.html':
 							case 'botany.html':
 							case 'presents.html':


### PR DESCRIPTION
In https://github.com/tgstation/tgstation/pull/65850, I combine `singulo.log` and `supermatter.log` into `engine.log`. Those files were in parsed logs, so engine should also be in parsed logs.