### PR TITLE
Enable dropdown for top navbar on desctop

### DIFF
--- a/tg.css
+++ b/tg.css
@@ -3126,6 +3126,9 @@ input[type="button"].btn-block {
     left: 0;
     right: auto;
   }
+  .navbar-nav > .dropdown:hover > .dropdown-menu{
+    display: block;
+  }
 }
 .btn-group,
 .btn-group-vertical {


### PR DESCRIPTION
This is QOL pr and its enable navbar dropdown on mouse hover on devices that have width more then 768px. So mobiles are unaffected by this.