### PR TITLE
Add transport.log to public logs

### DIFF
--- a/public_log_parser.php
+++ b/public_log_parser.php
@@ -439,6 +439,7 @@ foreach ($servers as $server) {
 							case 'initialize.log':
 							case 'pda.log':
 							case 'telecomms.log':
+							case 'transport.log':
 							case 'overlay.log':
 							case 'manifest.log':
 							case 'job_debug.log':


### PR DESCRIPTION
Add transport.log to the public log parser, introduced in https://github.com/tgstation/tgstation/pull/78230