### PR TITLE
Fixes "other servers" links

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,11 +251,11 @@
 							<li><a href="https://8ch.net/tg/">/tg/ (8chan)</a></li>
 							<li><a href="https://8ch.net/vg/">/vg/ (8chan)</a></li>
 							<li><b>Other stations</b></li>
-							<li><a href="http://baystation12.net/">Bay Station</a></li> 
-							<li><a href="http://wiki.ss13.co/Main_Page">Goon Station</a></li>
+							<li><a href="https://baystation.xyz/">Bay Station</a></li> 
+							<li><a href="https://wiki.ss13.co/Main_Page">Goon Station</a></li>
 							<li><a href="https://www.yogstation.net/">Yog Station</a></li>
 							<li><a href="https://www.paradisestation.org/">Paradise Station</a></li>
-							<li><a href="http://www.colonial-marines.com/">Colonial Marines</a></li>
+							<li><a href="https://cm-ss13.com/">Colonial Marines</a></li>
 							<li><a href="http://hippiestation.com/">Hippie Station</a></li>
 						</ul>
 					</li>


### PR DESCRIPTION
Fixes the Baystation 12 and Colonial Marines links. Changes the Goon link to https

Fixes #86 